### PR TITLE
Fixes "Loading virus signature" rotation for x64

### DIFF
--- a/clamscan/manager.c
+++ b/clamscan/manager.c
@@ -122,7 +122,7 @@ static void rotate(cb_data_t *cbctx, const char *fmt)
     if ((cbctx->count++ % 100000) == 0)
     {
         mprintf(fmt, cbctx->filename, rotation[cbctx->oldvalue]);
-        cbctx->oldvalue = (cbctx->oldvalue + 1) % sizeof(rotation);
+        cbctx->oldvalue = (cbctx->oldvalue + 1) % 4;
     }
 }
 


### PR DESCRIPTION
`sizeof(rotation)` returns 8 instead of 4 on x64 builds. Specifying the exact amount of characters to be rotated prevents that the console prints multiple lines like: 
```Loading virus signature database, please wait... Loading virus signature database, please wait... Loading virus signature database, please wait... Loading virus signature database, please wait... Loading virus signature database, please wait...```